### PR TITLE
Add dockerize dep rsync

### DIFF
--- a/install-deps.sh
+++ b/install-deps.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 
-sudo apt-get install -y make busybox python-pip
+sudo apt-get install -y make busybox python-pip rsync
 sudo pip install https://github.com/larsks/dockerize/archive/master.zip


### PR DESCRIPTION
When using this in a Debian container, rsync wasn't installed so dockerize failed.

